### PR TITLE
Fix disk manager not releasing host level locks

### DIFF
--- a/helm/ydb-disk-manager/Chart.yaml
+++ b/helm/ydb-disk-manager/Chart.yaml
@@ -3,5 +3,5 @@ name: ydb-disk-manager
 
 type: application
 
-version: 0.2.8
-appVersion: 0.2.8
+version: 0.2.9
+appVersion: 0.2.9

--- a/internal/hostdev/disks.go
+++ b/internal/hostdev/disks.go
@@ -103,6 +103,8 @@ func (mgr *DiskManager) UpdateLocks(procPath string) error {
 	var containerLocks = make(map[string]uint64)
 	var hostLocks = make(map[string]uint64)
 
+	klog.V(5).Infof("mgr.DiskInodes: %v", mgr.DiskInodes)
+
 	for diskIno, diskPath := range foundDiskLocks {
 		_, exist := mgr.DiskInodes[diskIno]
 		if !exist {
@@ -114,23 +116,37 @@ func (mgr *DiskManager) UpdateLocks(procPath string) error {
 		}
 	}
 
-	for diskPath, diskIno := range containerLocks {
+	klog.V(5).Info("containerLocks map: %v", containerLocks)
+	klog.V(5).Infof("hostLocks map: %v", hostLocks)
+
+	for diskPath, _ := range containerLocks {
 		if _, exist := hostLocks[diskPath]; !exist {
-			// lock exist in container, but not in host disk
 			klog.V(0).Infof("Lock exist in container, but not in host disk: %s", diskPath)
-			klog.V(0).Infof("Setting lock to host disk: %s, inode %d...", diskPath, diskIno)
+
+			inoFromHost := uint64(0)
+			for ino, hostDiskPath := range mgr.DiskInodes {
+				if hostDiskPath == diskPath {
+					inoFromHost = ino
+					break
+				}
+			}
+
+			klog.V(0).Infof("Setting lock to host disk: %s, inode %d...", diskPath, inoFromHost)
 			file, err := setLock(diskPath)
 			if err != nil {
 				return err
 			}
-			mgr.fileLocks.locks[diskIno] = file
+
+			klog.V(3).Infof("setting host lock, inode:%v, lockfile:%v to fileLocks", inoFromHost, file)
+			mgr.fileLocks.locks[inoFromHost] = file
 		}
 	}
+
+	klog.V(5).Infof("mgr.fileLocks.locks map: %v", mgr.fileLocks.locks)
 
 	for diskPath, diskIno := range hostLocks {
 		if _, exist := containerLocks[diskPath]; !exist {
 			if file, exist := mgr.fileLocks.locks[diskIno]; exist {
-				// lock exist in host, but not in container disk
 				klog.V(0).Infof("Lock exist in host, but not in container disk: %s", diskPath)
 				klog.V(0).Infof("Releasing lock from host disk: %s, inode %d...", diskPath, diskIno)
 				if err := releaseLock(file); err != nil {
@@ -140,6 +156,7 @@ func (mgr *DiskManager) UpdateLocks(procPath string) error {
 			}
 		}
 	}
+
 	return nil
 }
 

--- a/internal/hostdev/disks.go
+++ b/internal/hostdev/disks.go
@@ -116,8 +116,8 @@ func (mgr *DiskManager) UpdateLocks(procPath string) error {
 		}
 	}
 
-	klog.V(5).Info("containerLocks map: %v", containerLocks)
-	klog.V(5).Infof("hostLocks map: %v", hostLocks)
+	klog.V(5).Infof("containerLocks: %v", containerLocks)
+	klog.V(5).Infof("hostLocks: %v", hostLocks)
 
 	for diskPath, _ := range containerLocks {
 		if _, exist := hostLocks[diskPath]; !exist {
@@ -142,7 +142,7 @@ func (mgr *DiskManager) UpdateLocks(procPath string) error {
 		}
 	}
 
-	klog.V(5).Infof("mgr.fileLocks.locks map: %v", mgr.fileLocks.locks)
+	klog.V(5).Infof("mgr.fileLocks.locks: %v", mgr.fileLocks.locks)
 
 	for diskPath, diskIno := range hostLocks {
 		if _, exist := containerLocks[diskPath]; !exist {


### PR DESCRIPTION
## Behavior prior to this commit

- even if YDB process released the disk inside the YDB container, ydb-disk-manager still kept holding to the lock indefinitely, and only stopped holding it after a forced ydb-disk-manager pod restart

## Reason
- bug in logic: disk inodes inside YDB container and inside ydb-disk-manager differ, and in this line `fileLocks.locks` map has been erroneously populated with YDB container diskInodes, but then in releasing logic checked as if there were ydb-disk-manager disk inodes.    

```
mgr.fileLocks.locks[diskIno] = file
```

## Behavior after this commit

- ydb-disk-manager correctly releases locks to disks on host level